### PR TITLE
Boss聊天页面Xpath查询元素优化

### DIFF
--- a/src/main/java/boss/Boss.java
+++ b/src/main/java/boss/Boss.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import utils.Job;
@@ -35,7 +36,7 @@ import static utils.JobUtils.formatDuration;
  * 项目链接: <a href="https://github.com/loks666/get_jobs">https://github.com/loks666/get_jobs</a>
  * Boss直聘自动投递
  */
-public class Boss {
+public class BossTest {
     static final int noJobMaxPages = 10; // 无岗位最大页数
     private static final Logger log = LoggerFactory.getLogger(Boss.class);
     static Integer page = 1;
@@ -52,7 +53,7 @@ public class Boss {
     static int lastSize;
     static Date startDate;
     static BossConfig config = BossConfig.init();
-	static int maxPages = 10;
+    static int maxPages = 10;
 
     public static void main(String[] args) {
         loadData(dataPath);
@@ -294,7 +295,7 @@ public class Boss {
 
     @SneakyThrows
     private static Integer resumeSubmission(String keyword) {
-		//禁用resumeSubmission中点击页码
+        //禁用resumeSubmission中点击页码
         //CHROME_DRIVER.get(url + "&query=" + keyword);
         //try {
         //    WAIT.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='job-list-wrapper']")));
@@ -404,14 +405,14 @@ public class Boss {
                     WebElement send = WAIT.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//button[@type='send']")));
                     send.click();
                     SeleniumUtil.sleep(3);
-                    WebElement recruiterNameElement = CHROME_DRIVER.findElement(By.xpath("//p[@class='base-info fl']/span[@class='name']"));
-                    WebElement recruiterTitleElement = CHROME_DRIVER.findElement(By.xpath("//p[@class='base-info fl']/span[@class='base-title']"));
+                    WebElement recruiterNameElement = CHROME_DRIVER.findElement(By.xpath("//div[@class='base-info']/div[@class='name-content']/span[@class='name-text']"));
+                    WebElement recruiterTitleElement = CHROME_DRIVER.findElement(By.xpath("//div[@class='base-info']/span[@class='base-title']"));
                     String recruiter = recruiterNameElement.getText() + " " + recruiterTitleElement.getText();
 
                     WebElement companyElement = null;
                     try {
                         // 通过定位父元素后获取第二个 span 元素，获取公司名
-                        companyElement = CHROME_DRIVER.findElement(By.xpath("//p[@class='base-info fl']/span[2]"));
+                        companyElement = CHROME_DRIVER.findElement(By.xpath("//div[@class='base-info']/span[1]"));
                     } catch (Exception e) {
                         log.info("获取公司名异常！");
                     }
@@ -420,9 +421,9 @@ public class Boss {
                         company = companyElement.getText();
                         job.setCompanyName(company);
                     }
-                    WebElement positionNameElement = CHROME_DRIVER.findElement(By.xpath("//a[@class='position-content']/span[@class='position-name']"));
-                    WebElement salaryElement = CHROME_DRIVER.findElement(By.xpath("//a[@class='position-content']/span[@class='salary']"));
-                    WebElement cityElement = CHROME_DRIVER.findElement(By.xpath("//a[@class='position-content']/span[@class='city']"));
+                    WebElement positionNameElement = CHROME_DRIVER.findElement(By.xpath("//div[@class='left-content']/span[@class='position-name']"));
+                    WebElement salaryElement = CHROME_DRIVER.findElement(By.xpath("//div[@class='left-content']/span[@class='salary']"));
+                    WebElement cityElement = CHROME_DRIVER.findElement(By.xpath("//div[@class='left-content']/span[@class='city']"));
                     String position = positionNameElement.getText() + " " + salaryElement.getText() + " " + cityElement.getText();
                     company = company == null ? "未知公司: " + job.getHref() : company;
                     Boolean imgResume = sendResume(company);


### PR DESCRIPTION
Boss聊天页面Xpth查询recruiterNameElement、recruiterTitleElement、companyElement、positionNameElement、salaryElement、cityElement元素优化，防止报错导致投递简历图片失败。
![get_jobs_error](https://github.com/user-attachments/assets/372da460-e2ce-4e06-9ead-9554406f90fc)
