### PR TITLE
Update Boss转化字符串方法

### DIFF
--- a/src/main/java/boss/Boss.java
+++ b/src/main/java/boss/Boss.java
@@ -275,18 +275,25 @@ public class Boss {
     }
 
 
-    private static String customJsonFormat(Map<String, Set<String>> data) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\n");
-        for (Map.Entry<String, Set<String>> entry : data.entrySet()) {
-            sb.append("    \"").append(entry.getKey()).append("\": [\n");
-            sb.append(entry.getValue().stream().map(s -> "        \"" + s + "\"").collect(Collectors.joining(",\n")));
-
-            sb.append("\n    ],\n");
-        }
-        sb.delete(sb.length() - 2, sb.length());
-        sb.append("\n}");
-        return sb.toString();
+       private static String customJsonFormat(Map<String, List<String>> data) {
+        // 创建 Gson 对象，并启用 pretty printing 以美化 JSON 输出
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        // 使用 Gson 将 Map 转换为 JSON 字符串
+        return gson.toJson(data);
+        //{
+        //  "blackCompanies": [
+        //    "公司A",
+        //    "公司B"
+        //  ],
+        //  "blackRecruiters": [
+        //    "招聘者A",
+        //    "招聘者B"
+        //  ],
+        //  "blackJobs": [
+        //    "职位A",
+        //    "职位B"
+        //  ]
+        //}
     }
 
     private static void loadData(String path) {


### PR DESCRIPTION
使用Gson库替换原customJsonFormat方法可以缩短转化Json字符串的代码行数，使其更简便，可维护性增强，性能提高