### PR TITLE
# liepin update and fix

### DIFF
--- a/src/main/java/liepin/Liepin.java
+++ b/src/main/java/liepin/Liepin.java
@@ -143,7 +143,7 @@ public class Liepin {
                 log.info("命中已排除公司：{}", companyName);
                 continue;
             }
-            if (CONTAINS_JOB_NAME.stream().noneMatch(jobName::contains)){
+            if (!CONTAINS_JOB_NAME.isEmpty() && CONTAINS_JOB_NAME.stream().noneMatch(jobName::contains)){
                 log.info("命中未包含的工作名：{}",jobName);
                 continue;
             }

--- a/src/main/java/liepin/LiepinEnum.java
+++ b/src/main/java/liepin/LiepinEnum.java
@@ -18,7 +18,9 @@ public class LiepinEnum {
         GUANGZHOU("广州", "050020"),
         SHENZHEN("深圳", "050090"),
         WUHAN("武汉", "170020"),
-        CHENGDU("成都", "280020");
+        CHENGDU("成都", "280020"),
+        HANGZHOU("杭州", "070020");
+
 
         private final String name;
         private final String code;


### PR DESCRIPTION
- add HANGZHOU("杭州", "070020"); in LiepinEnum
- 补充containsJobName判空，支持可选参数配置（keywords能覆盖其功能，containsJobName作为进一步的过滤）