### PR TITLE
:art: refactor(front): replace hardcoded localhost:8888 with API_BASE env var

### DIFF
--- a/front/app/ai-config/page.tsx
+++ b/front/app/ai-config/page.tsx
@@ -7,6 +7,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import PageHeader from '@/app/components/PageHeader'
+const API_BASE = process.env.API_BASE_URL || 'http://localhost:8888'
+
 
 export default function AiConfigPage() {
   const [aiConfig, setAiConfig] = useState({
@@ -26,7 +28,7 @@ export default function AiConfigPage() {
 
   const fetchAiConfig = async () => {
     try {
-      const response = await fetch('http://localhost:8888/api/ai/config', {
+      const response = await fetch(`${API_BASE}/api/ai/config`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
@@ -54,7 +56,7 @@ export default function AiConfigPage() {
   // 加载 boss_config 的 enable_ai 字段
   const fetchEnableAi = async () => {
     try {
-      const response = await fetch('http://localhost:8888/api/boss/config', {
+      const response = await fetch(`${API_BASE}/api/boss/config`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
@@ -79,7 +81,7 @@ export default function AiConfigPage() {
     try {
       const next = enableAi ? 0 : 1
       setEnableAi(next)
-      const response = await fetch('http://localhost:8888/api/boss/config', {
+      const response = await fetch(`${API_BASE}/api/boss/config`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -103,7 +105,7 @@ export default function AiConfigPage() {
     setLoading(true)
     try {
       // 保存AI配置
-      const response = await fetch('http://localhost:8888/api/ai/config', {
+      const response = await fetch(`${API_BASE}/api/ai/config`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/front/app/boss/analysis/AnalysisContent.tsx
+++ b/front/app/boss/analysis/AnalysisContent.tsx
@@ -64,7 +64,7 @@ type PagedResult = {
   size: number
 }
 
-const API_BASE = "http://localhost:8888"
+const API_BASE = process.env.API_BASE_URL || 'http://localhost:8888'
 // 通用分类颜色（用于柱状/饼状图每个分类不同颜色）
 const CATEGORY_COLORS = [
   "#3b82f6",

--- a/front/app/boss/page.tsx
+++ b/front/app/boss/page.tsx
@@ -12,6 +12,8 @@ import { Select } from '@/components/ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import PageHeader from '@/app/components/PageHeader'
 import AnalysisContent from '@/app/boss/analysis/AnalysisContent'
+const API_BASE = process.env.API_BASE_URL || 'http://localhost:8888'
+
 
 interface BossConfig {
   id?: number
@@ -115,7 +117,7 @@ export default function BossPage() {
       return
     }
 
-    const client = createSSEWithBackoff('http://localhost:8888/api/jobs/login-status/stream', {
+    const client = createSSEWithBackoff(`${API_BASE}/api/jobs/login-status/stream`, {
       onOpen: () => {
         console.log('[SSE] 连接已打开')
       },
@@ -161,7 +163,7 @@ export default function BossPage() {
 
   const fetchAllData = async () => {
     try {
-      const response = await fetch('http://localhost:8888/api/boss/config')
+      const response = await fetch(`${API_BASE}/api/boss/config`)
       const data = await response.json()
 
       console.log('Fetched data:', data)
@@ -382,7 +384,7 @@ export default function BossPage() {
         stage: toBracketList(selectedStage),
         salary: toBracketList(selectedSalary),
       }
-      const response = await fetch('http://localhost:8888/api/boss/config', {
+      const response = await fetch(`${API_BASE}/api/boss/config`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -393,7 +395,7 @@ export default function BossPage() {
       if (response.ok) {
         // 统一保存 Cookie（Boss）
         try {
-          await fetch('http://localhost:8888/api/cookie/save?platform=boss', { method: 'POST' })
+          await fetch(`${API_BASE}/api/cookie/save?platform=boss`, { method: 'POST' })
         } catch (e) {
           console.warn('保存 Cookie 失败（Boss）:', e)
         }
@@ -428,7 +430,7 @@ export default function BossPage() {
     }
 
     try {
-      const response = await fetch('http://localhost:8888/api/boss/config/blacklist', {
+      const response = await fetch(`${API_BASE}/api/boss/config/blacklist`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -454,7 +456,7 @@ export default function BossPage() {
 
   const handleDeleteBlacklist = async (id: number) => {
     try {
-      const response = await fetch(`http://localhost:8888/api/boss/config/blacklist/${id}`, {
+      const response = await fetch(`${API_BASE}/api/boss/config/blacklist/${id}`, {
         method: 'DELETE',
       })
 
@@ -473,7 +475,7 @@ export default function BossPage() {
   const handleStartDelivery = async () => {
     try {
       setIsDelivering(true)
-      const response = await fetch('http://localhost:8888/api/boss/start', {
+      const response = await fetch(`${API_BASE}/api/boss/start`, {
         method: 'POST',
       })
       const data = await response.json()
@@ -494,7 +496,7 @@ export default function BossPage() {
 
   const handleStopDelivery = async () => {
     try {
-      const response = await fetch('http://localhost:8888/api/boss/stop', {
+      const response = await fetch(`${API_BASE}/api/boss/stop`, {
         method: 'POST',
       })
       const data = await response.json()
@@ -516,7 +518,7 @@ export default function BossPage() {
 
   const triggerLogout = async () => {
     try {
-      const response = await fetch('http://localhost:8888/api/boss/logout', { method: 'POST' })
+      const response = await fetch(`${API_BASE}/api/boss/logout`, { method: 'POST' })
       const data = await response.json()
       if (data.success) {
         setIsLoggedIn(false)

--- a/front/app/env-config/page.tsx
+++ b/front/app/env-config/page.tsx
@@ -7,6 +7,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import PageHeader from '@/app/components/PageHeader'
+const API_BASE = process.env.API_BASE_URL || 'http://localhost:8888'
+
 
 export default function EnvConfig() {
   const [envConfig, setEnvConfig] = useState({
@@ -27,7 +29,7 @@ export default function EnvConfig() {
   const fetchConfig = async () => {
     try {
       setLoading(true)
-      const response = await fetch('http://localhost:8888/api/config', {
+      const response = await fetch(`${API_BASE}/api/config`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
@@ -77,7 +79,7 @@ export default function EnvConfig() {
         BOT_IS_SEND: String(envConfig.botIsSend ?? 0),
       }
 
-      const response = await fetch('http://localhost:8888/api/config', {
+      const response = await fetch(`${API_BASE}/api/config`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/front/app/liepin/analysis/AnalysisContent.tsx
+++ b/front/app/liepin/analysis/AnalysisContent.tsx
@@ -60,7 +60,7 @@ type PagedResult = {
   size: number
 }
 
-const API_BASE = "http://localhost:8888"
+const API_BASE = process.env.API_BASE_URL || 'http://localhost:8888'
 const CATEGORY_COLORS = [
   "#3b82f6",
   "#10b981",

--- a/front/app/liepin/page.tsx
+++ b/front/app/liepin/page.tsx
@@ -11,6 +11,8 @@ import { Select } from '@/components/ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import AnalysisContent from '@/app/liepin/analysis/AnalysisContent'
 import PageHeader from '@/app/components/PageHeader'
+const API_BASE = process.env.API_BASE_URL || 'http://localhost:8888'
+
 
 interface LiepinConfig {
   id?: number
@@ -60,7 +62,7 @@ export default function LiepinPage() {
       return
     }
 
-    const client = createSSEWithBackoff('http://localhost:8888/api/jobs/login-status/stream', {
+    const client = createSSEWithBackoff(`${API_BASE}/api/jobs/login-status/stream`, {
       onOpen: () => {
         console.log('[SSE] 连接已打开')
       },
@@ -134,7 +136,7 @@ export default function LiepinPage() {
 
   const fetchAllData = async () => {
     try {
-      const response = await fetch('http://localhost:8888/api/liepin/config')
+      const response = await fetch(`${API_BASE}/api/liepin/config`)
       const data = await response.json()
 
       console.log('Fetched liepin data:', data)
@@ -162,7 +164,7 @@ export default function LiepinPage() {
   const handleSave = async () => {
     try {
       const payload = { ...config, keywords: serializeKeywordsForDb(config.keywords) }
-      const response = await fetch('http://localhost:8888/api/liepin/config', {
+      const response = await fetch(`${API_BASE}/api/liepin/config`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -173,7 +175,7 @@ export default function LiepinPage() {
       if (response.ok) {
         // 统一保存 Cookie（Liepin）
         try {
-          await fetch('http://localhost:8888/api/cookie/save?platform=liepin', { method: 'POST' })
+          await fetch(`${API_BASE}/api/cookie/save?platform=liepin`, { method: 'POST' })
         } catch (e) {
           console.warn('保存 Cookie 失败（Liepin）:', e)
         }
@@ -196,7 +198,7 @@ export default function LiepinPage() {
   const handleStartDelivery = async () => {
     try {
       setIsDelivering(true)
-      const response = await fetch('http://localhost:8888/api/liepin/start', {
+      const response = await fetch(`${API_BASE}/api/liepin/start`, {
         method: 'POST',
       })
       const data = await response.json()
@@ -217,7 +219,7 @@ export default function LiepinPage() {
 
   const handleStopDelivery = async () => {
     try {
-      const response = await fetch('http://localhost:8888/api/liepin/stop', {
+      const response = await fetch(`${API_BASE}/api/liepin/stop`, {
         method: 'POST',
       })
       const data = await response.json()
@@ -237,7 +239,7 @@ export default function LiepinPage() {
 
   const triggerLogout = async () => {
     try {
-      const response = await fetch('http://localhost:8888/api/liepin/logout', { method: 'POST' })
+      const response = await fetch(`${API_BASE}/api/liepin/logout`, { method: 'POST' })
       const data = await response.json()
       if (data.success) {
         setIsLoggedIn(false)

--- a/front/app/zhilian/page.tsx
+++ b/front/app/zhilian/page.tsx
@@ -11,6 +11,8 @@ import { Select } from '@/components/ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import AnalysisContent from '@/app/zhilian/analysis/AnalysisContent'
 import PageHeader from '@/app/components/PageHeader'
+const API_BASE = process.env.API_BASE_URL || 'http://localhost:8888'
+
 
 interface ZhilianConfig {
   id?: number
@@ -44,7 +46,7 @@ export default function ZhilianPage() {
       return
     }
 
-    const client = createSSEWithBackoff('http://localhost:8888/api/jobs/login-status/stream', {
+    const client = createSSEWithBackoff(`${API_BASE}/api/jobs/login-status/stream`, {
       onOpen: () => console.log('[智联招聘 SSE] 连接已打开'),
       onError: (e, attempt, delay) => {
         console.warn(`[智联招聘 SSE] 连接错误，第${attempt}次重连，延迟 ${delay}ms`, e)
@@ -116,7 +118,7 @@ export default function ZhilianPage() {
 
   const fetchAllData = async () => {
     try {
-      const res = await fetch('http://localhost:8888/api/zhilian/config')
+      const res = await fetch(`${API_BASE}/api/zhilian/config`)
       const data = await res.json()
       if (data.config) {
         const normalized = { ...data.config }
@@ -137,7 +139,7 @@ export default function ZhilianPage() {
   useEffect(() => {
     (async () => {
       try {
-        const res = await fetch('http://localhost:8888/api/zhilian/config', { method: 'GET' })
+        const res = await fetch(`${API_BASE}/api/zhilian/config`, { method: 'GET' })
         const ok = !!res && res.ok
         setBackendAvailable(ok)
         if (ok) {
@@ -156,7 +158,7 @@ export default function ZhilianPage() {
   const handleStartDelivery = async () => {
     try {
       setIsDelivering(true)
-      const response = await fetch('http://localhost:8888/api/zhilian/start', { method: 'POST' })
+      const response = await fetch(`${API_BASE}/api/zhilian/start`, { method: 'POST' })
       const data = await response.json()
       if (!data.success) setIsDelivering(false)
     } catch (error) {
@@ -166,7 +168,7 @@ export default function ZhilianPage() {
 
   const handleStopDelivery = async () => {
     try {
-      const response = await fetch('http://localhost:8888/api/zhilian/stop', { method: 'POST' })
+      const response = await fetch(`${API_BASE}/api/zhilian/stop`, { method: 'POST' })
       const data = await response.json()
       if (data.success) setIsDelivering(false)
     } catch (error) {}
@@ -174,7 +176,7 @@ export default function ZhilianPage() {
 
   const triggerLogout = async () => {
     try {
-      const response = await fetch('http://localhost:8888/api/zhilian/logout', { method: 'POST' })
+      const response = await fetch(`${API_BASE}/api/zhilian/logout`, { method: 'POST' })
       const data = await response.json()
       setIsLoggedIn(false)
       setLogoutResult({ success: data.success, message: data.success ? '已退出登录，Cookie已清空。' : data.message })
@@ -187,7 +189,7 @@ export default function ZhilianPage() {
 
   const handleSaveCookie = async () => {
     try {
-      const response = await fetch('http://localhost:8888/api/cookie/save?platform=zhilian', { method: 'POST' })
+      const response = await fetch(`${API_BASE}/api/cookie/save?platform=zhilian`, { method: 'POST' })
       const data = await response.json()
       setSaveResult({ success: data.success, message: data.success ? '配置保存成功。' : data.message })
       setShowSaveDialog(true)
@@ -200,13 +202,13 @@ export default function ZhilianPage() {
   const handleSaveConfig = async () => {
     try {
       const payload = { ...config, keywords: serializeKeywordsForDb(config.keywords) }
-      const response = await fetch('http://localhost:8888/api/zhilian/config', {
+      const response = await fetch(`${API_BASE}/api/zhilian/config`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       })
       if (response.ok) {
-        try { await fetch('http://localhost:8888/api/cookie/save?platform=zhilian', { method: 'POST' }) } catch {}
+        try { await fetch(`${API_BASE}/api/cookie/save?platform=zhilian`, { method: 'POST' }) } catch {}
         await fetchAllData()
         setSaveResult({ success: true, message: '保存成功，配置已更新。' })
       } else {


### PR DESCRIPTION
将所有前端页面中硬编码的 \http://localhost:8888\ 替换为 \\\ 模板字符串，统一通过 \
ext.config.ts\ 中配置的 \process.env.API_BASE_URL\ 管理。保留 localhost:8888 作为开发环境 fallback 值。

### 涉及文件
- boss/page.tsx
- boss/analysis/AnalysisContent.tsx
- liepin/page.tsx
- liepin/analysis/AnalysisContent.tsx
- zhilian/page.tsx
- env-config/page.tsx
- ai-config/page.tsx

### 改动说明
- 定义 \const API_BASE = process.env.API_BASE_URL || 'http://localhost:8888'\
- 所有 fetch/createSSEWithBackoff 调用使用 \\\ 拼接 URL
- Sidebar.tsx 和 51job 页面已正确使用该模式，本次统一其余页面