### PR TITLE
[codex] 修复 BOSS 黑名单误判规则

### DIFF
--- a/src/main/java/com/getjobs/application/service/BossService.java
+++ b/src/main/java/com/getjobs/application/service/BossService.java
@@ -408,6 +408,9 @@ public class BossService {
         List<BlacklistEntity> list = blacklistMapper.selectList(wrapper);
         return list.stream()
                 .map(BlacklistEntity::getValue)
+                .filter(java.util.Objects::nonNull)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
                 .collect(Collectors.toSet());
     }
 
@@ -440,6 +443,11 @@ public class BossService {
      * @return 是否成功
      */
     public boolean addBlacklist(String type, String value) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
+        value = value.trim();
+
         // 检查是否已存在
         LambdaQueryWrapper<BlacklistEntity> wrapper = new LambdaQueryWrapper<>();
         wrapper.eq(BlacklistEntity::getType, type)

--- a/src/main/java/com/getjobs/worker/boss/Boss.java
+++ b/src/main/java/com/getjobs/worker/boss/Boss.java
@@ -42,6 +42,12 @@ import static com.getjobs.worker.boss.Locators.*;
 @RequiredArgsConstructor
 public class Boss {
 
+    private static final List<String> REJECTION_PHRASES = List.of(
+            "不合适", "不匹配", "不符合", "暂不考虑", "暂时不考虑",
+            "已招满", "招满了", "岗位已关闭", "职位已关闭", "招聘已结束",
+            "未通过", "没有通过", "很遗憾", "抱歉", "对不起", "感谢投递"
+    );
+
     @Setter
     private Page page;
     @Setter
@@ -161,14 +167,11 @@ public class Boss {
                     }
 
                     if (companyName != null && message != null) {
-                        boolean match = message.contains("不") || message.contains("感谢") || message.contains("但")
-                                || message.contains("遗憾") || message.contains("需要本") || message.contains("对不");
-                        boolean nomatch = message.contains("不是") || message.contains("不生");
-                        if (match && !nomatch) {
-                            if (blackCompanies.stream().anyMatch(companyName::contains)) {
+                        if (isRejectionMessage(message)) {
+                            companyName = companyName.replaceAll("\\.{3}", "").trim();
+                            if (matchesCompanyBlacklist(blackCompanies, companyName)) {
                                 continue;
                             }
-                            companyName = companyName.replaceAll("\\.{3}", "");
                             if (companyName.matches(".*(\\p{IsHan}{2,}|[a-zA-Z]{4,}).*")) {
                                 blackCompanies.add(companyName);
                                 // 保存到数据库
@@ -357,7 +360,7 @@ public class Boss {
                 }
 
                 // 过滤（全部基于 JSON 字段），并输出过滤原因
-                if (jobName != null && blackJobs != null && blackJobs.stream().anyMatch(jobName::contains)) {
+                if (matchesBlacklist(blackJobs, jobName)) {
                     String term = findMatchedTerm(blackJobs, jobName);
                     log.info("被过滤：职位黑名单命中 | 公司：{} | 岗位：{} | 关键词：{}", bossCompany != null ? bossCompany : "", jobName, term != null ? term : "");
                     continue;
@@ -368,12 +371,12 @@ public class Boss {
                     log.info("被过滤：HR活跃状态包含‘年’ | 公司：{} | 岗位：{} | 活跃：{}", bossCompany != null ? bossCompany : "", jobName != null ? jobName : "", bossActive);
                     continue;
                 }
-                if (bossCompany != null && blackCompanies != null && blackCompanies.stream().anyMatch(bossCompany::contains)) {
-                    String term = findMatchedTerm(blackCompanies, bossCompany);
+                if (matchesCompanyBlacklist(blackCompanies, bossCompany)) {
+                    String term = findMatchedCompanyTerm(blackCompanies, bossCompany);
                     log.info("被过滤：公司黑名单命中 | 公司：{} | 岗位：{} | 关键词：{}", bossCompany, jobName != null ? jobName : "", term != null ? term : "");
                     continue;
                 }
-                if (bossJobTitle != null && blackRecruiters != null && blackRecruiters.stream().anyMatch(bossJobTitle::contains)) {
+                if (matchesBlacklist(blackRecruiters, bossJobTitle)) {
                     String term = findMatchedTerm(blackRecruiters, bossJobTitle);
                     log.info("被过滤：招聘者黑名单命中 | 公司：{} | 岗位：{} | 招聘者：{} | 关键词：{}", bossCompany != null ? bossCompany : "", jobName != null ? jobName : "", bossJobTitle, term != null ? term : "");
                     continue;
@@ -466,9 +469,9 @@ public class Boss {
             String positionName = entity.getJobName() != null ? entity.getJobName() : "";
             String hrPosition = entity.getHrPosition() != null ? entity.getHrPosition() : "";
             try {
-                if (blackCompanies != null && blackCompanies.stream().anyMatch(companyName::contains)) filtered = true;
-                if (!filtered && blackJobs != null && blackJobs.stream().anyMatch(positionName::contains)) filtered = true;
-                if (!filtered && blackRecruiters != null && blackRecruiters.stream().anyMatch(hrPosition::contains)) filtered = true;
+                if (matchesCompanyBlacklist(blackCompanies, companyName)) filtered = true;
+                if (!filtered && matchesBlacklist(blackJobs, positionName)) filtered = true;
+                if (!filtered && matchesBlacklist(blackRecruiters, hrPosition)) filtered = true;
             } catch (Throwable ignore) {}
 
             // HR活跃状态过滤：开启过滤且活跃描述包含“年”，则标记为已过滤，但仍入库
@@ -560,18 +563,54 @@ public class Boss {
         return new String[]{company, job};
     }
 
+    static boolean isRejectionMessage(String message) {
+        if (message == null || message.isBlank()) return false;
+        return REJECTION_PHRASES.stream().anyMatch(message::contains);
+    }
+
+    static boolean matchesBlacklist(Collection<String> patterns, String text) {
+        return findMatchedTerm(patterns, text) != null;
+    }
+
     // 匹配命中词条（用于日志输出过滤原因）
-    private String findMatchedTerm(java.util.Collection<String> patterns, String text) {
+    static String findMatchedTerm(Collection<String> patterns, String text) {
         if (patterns == null || text == null) return null;
-        try {
-            for (String p : patterns) {
-                if (p != null && !p.isEmpty() && text.contains(p)) {
-                    return p;
-                }
+        for (String pattern : patterns) {
+            if (pattern == null) continue;
+            String term = pattern.trim();
+            if (!term.isEmpty() && text.contains(term)) {
+                return term;
             }
-        } catch (Exception ignore) {
         }
         return null;
+    }
+
+    static boolean matchesCompanyBlacklist(Collection<String> patterns, String companyName) {
+        return findMatchedCompanyTerm(patterns, companyName) != null;
+    }
+
+    static String findMatchedCompanyTerm(Collection<String> patterns, String companyName) {
+        if (patterns == null || companyName == null) return null;
+        String normalizedCompany = normalizeCompanyName(companyName);
+        if (normalizedCompany.isEmpty()) return null;
+
+        for (String pattern : patterns) {
+            if (pattern == null) continue;
+            String term = pattern.trim();
+            String normalizedTerm = normalizeCompanyName(term);
+            if (normalizedTerm.isEmpty()) continue;
+
+            int termLength = normalizedTerm.codePointCount(0, normalizedTerm.length());
+            boolean matched = termLength < 4
+                    ? normalizedCompany.equals(normalizedTerm)
+                    : normalizedCompany.contains(normalizedTerm);
+            if (matched) return term;
+        }
+        return null;
+    }
+
+    private static String normalizeCompanyName(String value) {
+        return value.trim().replaceAll("\\s+", "").toLowerCase(Locale.ROOT);
     }
 
     public static String buildSearchUrl(BossConfig config, String cityCode) {

--- a/src/test/java/com/getjobs/application/service/BossServiceBlacklistTest.java
+++ b/src/test/java/com/getjobs/application/service/BossServiceBlacklistTest.java
@@ -1,0 +1,56 @@
+package com.getjobs.application.service;
+
+import com.getjobs.application.entity.BlacklistEntity;
+import com.getjobs.application.mapper.BlacklistMapper;
+import com.getjobs.application.mapper.BossConfigMapper;
+import com.getjobs.application.mapper.BossIndustryMapper;
+import com.getjobs.application.mapper.BossJobDataMapper;
+import com.getjobs.application.mapper.BossOptionMapper;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BossServiceBlacklistTest {
+
+    private final BlacklistMapper blacklistMapper = mock(BlacklistMapper.class);
+    private final BossService service = new BossService(
+            mock(BossOptionMapper.class),
+            mock(BossIndustryMapper.class),
+            mock(BossConfigMapper.class),
+            blacklistMapper,
+            mock(BossJobDataMapper.class),
+            mock(DataSource.class)
+    );
+
+    @Test
+    void blacklistValuesAreTrimmedAndBlanksAreDiscarded() {
+        when(blacklistMapper.selectList(any())).thenReturn(List.of(
+                blacklist(" 法本信息 "), blacklist("   "), blacklist(null)
+        ));
+
+        assertEquals(java.util.Set.of("法本信息"), service.getBlacklistByType("company"));
+    }
+
+    @Test
+    void blankBlacklistValueIsNotPersisted() {
+        assertFalse(service.addBlacklist("company", "   "));
+        assertFalse(service.addBlacklist("company", null));
+
+        verify(blacklistMapper, never()).insert(any(BlacklistEntity.class));
+    }
+
+    private static BlacklistEntity blacklist(String value) {
+        BlacklistEntity entity = new BlacklistEntity();
+        entity.setValue(value);
+        return entity;
+    }
+}

--- a/src/test/java/com/getjobs/worker/boss/BossBlacklistRulesTest.java
+++ b/src/test/java/com/getjobs/worker/boss/BossBlacklistRulesTest.java
@@ -1,0 +1,48 @@
+package com.getjobs.worker.boss;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BossBlacklistRulesTest {
+
+    @Test
+    void onlyExplicitRejectionMessagesAreDetected() {
+        assertTrue(Boss.isRejectionMessage("很遗憾，您的简历未通过筛选"));
+        assertTrue(Boss.isRejectionMessage("感谢投递，该岗位暂不考虑新人"));
+
+        assertFalse(Boss.isRejectionMessage("不知道是否方便沟通"));
+        assertFalse(Boss.isRejectionMessage("感谢回复，我们约时间聊聊"));
+        assertFalse(Boss.isRejectionMessage("但是该岗位需要尽快到岗"));
+    }
+
+    @Test
+    void blankBlacklistTermsNeverMatch() {
+        Set<String> patterns = new java.util.HashSet<>();
+        patterns.add("");
+        patterns.add("   ");
+        patterns.add(null);
+
+        assertFalse(Boss.matchesBlacklist(patterns, "任意岗位"));
+        assertFalse(Boss.matchesCompanyBlacklist(patterns, "任意公司"));
+    }
+
+    @Test
+    void shortCompanyTermsRequireExactMatch() {
+        Set<String> patterns = Set.of("法本");
+
+        assertTrue(Boss.matchesCompanyBlacklist(patterns, " 法本 "));
+        assertFalse(Boss.matchesCompanyBlacklist(patterns, "法本科技"));
+        assertFalse(Boss.matchesCompanyBlacklist(patterns, "广州市法本科技有限公司"));
+    }
+
+    @Test
+    void longerCompanyTermsStillSupportFullCompanyNames() {
+        Set<String> patterns = Set.of("法本信息");
+
+        assertTrue(Boss.matchesCompanyBlacklist(patterns, "深圳法本信息技术有限公司"));
+    }
+}


### PR DESCRIPTION
## 修改内容

- 收窄 BOSS 聊天拒绝判断，只在命中明确拒绝话术时自动加入公司黑名单
- 黑名单读取和写入时统一 trim，并过滤 null、空字符串和纯空格规则
- 公司短词改为规范化精确匹配，避免类似“法本”误伤其他公司；较长公司词仍支持子串匹配
- 职位、招聘者和公司过滤统一使用安全匹配方法
- 新增拒绝话术、空白规则和公司短词匹配测试

## 原因

原实现使用单字“不”“但”和通用词“感谢”判断拒绝，正常沟通内容也可能被识别成拒绝；同时空白黑名单值会被 `String.contains("")` 全量命中，公司短词的任意子串匹配也容易误伤。

## 影响

减少正常公司被自动加入黑名单或岗位被错误过滤的情况，不改变现有职位和招聘者关键词的子串匹配行为。

## 验证

- `gradle test`：BUILD SUCCESSFUL
- 6 个新增测试通过，0 failures / 0 errors
- `git diff --check` 通过
